### PR TITLE
ci(.github/dependabot): targeting master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
     time: "07:00"
     timezone: America/New_York
   open-pull-requests-limit: 10
-  target-branch: development
+  target-branch: master


### PR DESCRIPTION
updates `target-branch` to point to master
